### PR TITLE
Plumb through protocol support to lower layers

### DIFF
--- a/internet.go
+++ b/internet.go
@@ -144,7 +144,7 @@ type IPv6Packet struct {
 	TrafficClass       uint8
 	FlowLabel          uint32 // This is a huge waste of space for a 20-bit field. Rethink?
 	Length             uint16
-	NextHeader         uint8
+	NextHeader         IPProtocol
 	HopLimit           uint8
 	SourceAddress      []byte
 	DestinationAddress []byte
@@ -177,17 +177,30 @@ func (p *IPv6Packet) FromBytes(data []byte) error {
 
 	// The remaining fields are simply aligned.
 	p.Length = getUint16(data[4:6], false)
-	p.NextHeader = uint8(data[6])
+	p.NextHeader = IPProtocol(data[6])
 	p.HopLimit = uint8(data[7])
 
 	p.SourceAddress = data[8:24]
 	p.DestinationAddress = data[24:40]
 
-	// The data is everything else.
-	// NOTE: This is untrue, there are potential subsequent headers in the packet. Currently I'm ignoring
-	// them to go all "minimim-viable-product" on this library. We'll swing back to it.
-	p.data = new(UnknownTransport)
-	p.data.FromBytes(data[40:])
+	// Following the fixed headers are a sequence of extension headers
+	// terminating in the transport data.
+	p.parseRemainingHeaders(data[40:])
 
 	return nil
+}
+
+func (p *IPv6Packet) parseRemainingHeaders(data []byte) {
+	// Currently we don't support any extension headers so if the next header
+	// isn't the transport data then give up and interpret it as an unknown
+	// transport type.
+	switch p.NextHeader {
+	case IPP_TCP:
+		p.data = new(TCPSegment)
+	case IPP_UDP:
+		p.data = new(UDPDatagram)
+	default:
+		p.data = new(UnknownTransport)
+	}
+	p.data.FromBytes(data)
 }

--- a/internet.go
+++ b/internet.go
@@ -128,11 +128,12 @@ func (p *IPv4Packet) buildTransportLayer(data []byte) {
 	switch p.Protocol {
 	case IPP_TCP:
 		p.data = new(TCPSegment)
-		p.data.FromBytes(data)
+	case IPP_UDP:
+		p.data = new(UDPDatagram)
 	default:
 		p.data = new(UnknownTransport)
-		p.data.FromBytes(data)
 	}
+	p.data.FromBytes(data)
 }
 
 //-------------------------------------------------------------------------------------------

--- a/link.go
+++ b/link.go
@@ -77,9 +77,10 @@ func (e *EthernetFrame) buildInternetLayer(data []byte) {
 	switch e.EtherType {
 	case ETHERTYPE_IPV4:
 		e.data = new(IPv4Packet)
-		e.data.FromBytes(data)
+	case ETHERTYPE_IPV6:
+		e.data = new(IPv6Packet)
 	default:
 		e.data = new(UnknownINet)
-		e.data.FromBytes(data)
 	}
+	e.data.FromBytes(data)
 }


### PR DESCRIPTION
I've fixed up a few cases where protocols weren't attempting to parse the next level protocol even though gopcap had support for it.

In particular I've fixed up the following cases:
- UDP in IPv4 and IPv6
- TCP in IPv6
- IPv6 in Ethernet
